### PR TITLE
enable to start with minimized

### DIFF
--- a/app_binder/MainWindow.xaml.cs
+++ b/app_binder/MainWindow.xaml.cs
@@ -31,6 +31,20 @@ namespace AppBinder
 
             }
             dataGrid_config.ItemsSource = configs;
+            this.Loaded += minimized_startup;
+        }
+
+        private void minimized_startup(object sender, RoutedEventArgs e)
+        {
+            string[] args = Environment.GetCommandLineArgs();
+            foreach (string arg in args)
+            {
+                if (arg == "-m" || arg == "--minimum")
+                {
+                    this.WindowState = WindowState.Minimized;
+                }
+            }
+            this.Loaded -= minimized_startup;
         }
 
         private void button_add_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
スタートアップにショートカットを配置して自動起動させる際に最小化で起動してほしかったので`-m`または`--minimum`オプションをつけると最小化して起動できるようにしました．

書き終わったあとでショートカットに最小化して起動の設定があることに気づいたので必要なければ閉じてもらって大丈夫です．